### PR TITLE
Type mappers for Swashbuckle.AspNetCore

### DIFF
--- a/Enum.Ext/Enum.Ext.AutoFixture.Tests/Enum.Ext.AutoFixture.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.AutoFixture.Tests/Enum.Ext.AutoFixture.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enum.Ext/Enum.Ext.EFCore.Tests/Enum.Ext.EFCore.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.EFCore.Tests/Enum.Ext.EFCore.Tests.csproj
@@ -8,19 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enum.Ext/Enum.Ext.NewtonsoftJson.Tests/Enum.Ext.NewtonsoftJson.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.NewtonsoftJson.Tests/Enum.Ext.NewtonsoftJson.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore.Tests/Enum.Ext.Swashbuckle.AspNetCore.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore.Tests/Enum.Ext.Swashbuckle.AspNetCore.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Enum.Ext.Swashbuckle.AspNetCore\Enum.Ext.Swashbuckle.AspNetCore.csproj" />
+    <ProjectReference Include="..\Enum.Ext.Tests.Shared\Enum.Ext.Tests.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore.Tests/ExtensionsTests.cs
+++ b/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore.Tests/ExtensionsTests.cs
@@ -1,0 +1,35 @@
+﻿using Enum.Ext.Tests.Shared;
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using NUnit.Framework;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Enum.Ext.Swashbuckle.AspNetCore.Tests
+{
+    [TestFixture]
+    public class ExtensionsTests
+    {
+        [Test]
+        public void ConfigureEnumExt_Should_Add_TypeMappers()
+        {
+            // Arrange
+            var swaggerGenOptions = new SwaggerGenOptions();
+
+            // Act
+            swaggerGenOptions.ConfigureEnumExt(typeof(Weekday).Assembly);
+
+            // Assert
+            swaggerGenOptions.SchemaGeneratorOptions
+                .CustomTypeMappings.TryGetValue(typeof(Weekday), out var mapping)
+                .Should().BeTrue();
+
+            var schema = mapping!.Invoke();
+
+            schema.Should().NotBeNull();
+            schema.Should().BeEquivalentTo(new OpenApiSchema
+            {
+                Type = "integer",
+            });
+        }
+    }
+}

--- a/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/Enum.Ext.Swashbuckle.AspNetCore.csproj
+++ b/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/Enum.Ext.Swashbuckle.AspNetCore.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.0.0</Version>
+    <Authors>Mauracher Simon, Juen Marcel</Authors>
+    <PackageProjectUrl>https://github.com/simonmau/enum_ext</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/simonmau/enum_ext</RepositoryUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Description>This package adds type mappings for Swashbuckle.AspNetCore</Description>
+    <PackageIcon>EXT.png</PackageIcon>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\Resources\Logo\EXT.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Enum.Ext" Version="1.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/Extensions.cs
+++ b/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/Extensions.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Enum.Ext.Swashbuckle.AspNetCore
+{
+    /// <summary>
+    /// Extension methods provided by Enum.Ext.Swashbuckle.AspNetCore
+    /// </summary>
+    public static class Extensions
+    {
+        /// <summary>
+        /// Adds mappings for <see cref="TypeSafeEnum{TValue, TKey}"/> when int or long is used as key
+        /// </summary>
+        /// <param name="options">The <see cref="SwaggerGenOptions"/> to which the mappings should be added</param>
+        /// <param name="assemblies">The assemblies in which should be searched for implementations of <see cref="TypeSafeEnum{TValue, TKey}"/>.
+        /// If no assemblies are specified the calling <see cref="Assembly"/> is used.</param>
+        public static void ConfigureEnumExt(this SwaggerGenOptions options, params Assembly[] assemblies)
+        {
+            IEnumerable<Type> types;
+
+            if (assemblies.Any())
+            {
+                types = assemblies.SelectMany(x => x.GetTypes()
+                    .Where(y => TypeUtil.IsDerived(y, typeof(TypeSafeEnum<,>))));
+            }
+            else
+            {
+                types = Assembly.GetCallingAssembly().GetTypes()
+                    .Where(y => TypeUtil.IsDerived(y, typeof(TypeSafeEnum<,>)));
+            }
+
+            foreach (var item in types)
+            {
+                var keyType = TypeUtil.GetKeyType(item, typeof(TypeSafeEnum<,>));
+
+                if (keyType == typeof(int) || keyType == typeof(long))
+                {
+                    options.MapType(item, () => new OpenApiSchema
+                    {
+                        Type = "integer",
+                    });
+                }
+            }
+        }
+    }
+}

--- a/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/TypeUtil.cs
+++ b/Enum.Ext/Enum.Ext.Swashbuckle.AspNetCore/TypeUtil.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Enum.Ext.Swashbuckle.AspNetCore
+{
+    internal static class TypeUtil
+    {
+        public static bool IsDerived(Type objectType, Type mainType)
+        {
+            Type currentType = objectType.BaseType;
+
+            if (currentType == null)
+            {
+                return false;
+            }
+
+            while (currentType != typeof(object))
+            {
+                if (currentType.IsGenericType && currentType.GetGenericTypeDefinition() == mainType)
+                    return true;
+
+                currentType = currentType.BaseType;
+            }
+
+            return false;
+        }
+
+        public static Type GetKeyType(Type objectType, Type mainType)
+        {
+            Type currentType = objectType.BaseType;
+
+            if (currentType == null)
+            {
+                return null;
+            }
+
+            while (currentType != typeof(object))
+            {
+                if (currentType.IsGenericType && currentType.GetGenericTypeDefinition() == mainType)
+                    return currentType.GenericTypeArguments[1];
+
+                currentType = currentType.BaseType;
+            }
+
+            return null;
+        }
+
+        public static List<TFieldType> GetFieldsOfType<TFieldType>(this Type type)
+        {
+            return type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(p => type.IsAssignableFrom(p.FieldType))
+                .Select(pi => (TFieldType)pi.GetValue(null))
+                .ToList();
+        }
+    }
+}

--- a/Enum.Ext/Enum.Ext.SystemTextJson.Tests/Enum.Ext.SystemTextJson.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.SystemTextJson.Tests/Enum.Ext.SystemTextJson.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enum.Ext/Enum.Ext.Tests/Enum.Ext.Tests.csproj
+++ b/Enum.Ext/Enum.Ext.Tests/Enum.Ext.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Enum.Ext/Enum.Ext.sln
+++ b/Enum.Ext/Enum.Ext.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29009.5
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32804.467
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enum.Ext", "Enum.Ext\Enum.Ext.csproj", "{14D333D9-B435-4977-89C0-3F9CE70EC724}"
 EndProject
@@ -23,7 +23,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enum.Ext.SystemTextJson.Tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enum.Ext.Tests.Shared", "Enum.Ext.Tests.Shared\Enum.Ext.Tests.Shared.csproj", "{F7D6AEE5-8D84-4A04-9967-DAE1D33EBE4D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enum.Ext.NewtonsoftJson.Tests", "Enum.Ext.NewtonsoftJson.Tests\Enum.Ext.NewtonsoftJson.Tests.csproj", "{E7391FC8-FD3D-4A3D-AB3E-D70FA1B93CF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Enum.Ext.NewtonsoftJson.Tests", "Enum.Ext.NewtonsoftJson.Tests\Enum.Ext.NewtonsoftJson.Tests.csproj", "{E7391FC8-FD3D-4A3D-AB3E-D70FA1B93CF1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enum.Ext.Swashbuckle.AspNetCore", "Enum.Ext.Swashbuckle.AspNetCore\Enum.Ext.Swashbuckle.AspNetCore.csproj", "{C836CB12-FA88-4FAC-AA7E-10AF0582EC6E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Enum.Ext.Swashbuckle.AspNetCore.Tests", "Enum.Ext.Swashbuckle.AspNetCore.Tests\Enum.Ext.Swashbuckle.AspNetCore.Tests.csproj", "{6CACA0EE-1C0D-4201-A942-B16AAA79C15E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +79,14 @@ Global
 		{E7391FC8-FD3D-4A3D-AB3E-D70FA1B93CF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7391FC8-FD3D-4A3D-AB3E-D70FA1B93CF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7391FC8-FD3D-4A3D-AB3E-D70FA1B93CF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C836CB12-FA88-4FAC-AA7E-10AF0582EC6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C836CB12-FA88-4FAC-AA7E-10AF0582EC6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C836CB12-FA88-4FAC-AA7E-10AF0582EC6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C836CB12-FA88-4FAC-AA7E-10AF0582EC6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CACA0EE-1C0D-4201-A942-B16AAA79C15E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CACA0EE-1C0D-4201-A942-B16AAA79C15E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CACA0EE-1C0D-4201-A942-B16AAA79C15E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CACA0EE-1C0D-4201-A942-B16AAA79C15E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ List of all packages that we currently offer:
     PM> Install-Package Enum.Ext.AutoFixture
     PM> Install-Package Enum.Ext.NewtonsoftJson
     PM> Install-Package Enum.Ext.SystemTextJson
+    PM> Install-Pakcage Enum.Ext.Swashbuckle.AspNetCore
 
 ### How to use
 
@@ -160,6 +161,20 @@ fixture.WithEnumExt();
 
 var weekday = fixture.Create<Weekday>();
 ```
+
+#### Type mappers for Swashbuckle.AspNetCore
+
+If you are using `int` or `long` as key type and want your enums to be correctly displayed in the swagger documentation, you can use
+
+```C#
+builder.Services.AddSwaggerGen(options =>
+{
+    ...
+    
+    options.ConfigureEnumExt(typeof(Weekday).Assembly);
+}
+```
+
 
 ### Enum.Ext in action
 


### PR DESCRIPTION
* Added new package that can be used to add type mappers for Swashbuckle.AspNetCore so that enums are correctly displayed in the swagger documentation